### PR TITLE
CC-1400: Fix bug with DNS tester

### DIFF
--- a/internal/stage_4_answers_section.go
+++ b/internal/stage_4_answers_section.go
@@ -23,6 +23,10 @@ func testReceiveAnswerInResponse(stageHarness *test_case_harness.TestCaseHarness
 		return fmt.Errorf("%s", err)
 	}
 
+	if len(response.Question) == 0 {
+		return friendlyQuestionErr(response)
+	}
+
 	if err := validateQuestion(DEFAULT_DOMAIN, &response.Question[0]); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix:

> panic: runtime error: index out of range [0] with length 0

The [0] with length 0 is from:

> if err := validateQuestion(DEFAULT_DOMAIN, **&response.Question[0]**); err != nil {